### PR TITLE
Migrate to Toggl v9 api, add stop timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,81 @@
-# of-start-toggl-timer
+# of-start-toggl-timer v2
 Start a toggl timer from within OmniFocus.
 
+## What's New in v2
+
+- **Toggle Functionality:** Run the automation once to start a timer, run it again on the same task to stop it
+- **API v9 Compliance:** Updated to use Toggl Track API v9 (v8 is being deprecated)
+- **Automatic Project Activation:** Archived projects are automatically reactivated when needed
+- **User Feedback:** Clear alerts showing whether timer started or stopped
+- **Improved Error Handling:** Better validation and error messages
+
 ## setup/installation
+
 To add this automation to OmniFocus download this repository as a zip file or clone it. Then right click on the file start-timer.omnifocusjs and open in OmniFocus.
 
-First, you will need to add your Toggl API key at the beginning of the file. To open the file, go to the Automation menu in OmniFocus, click Configure, select this automation, click Reveal in Finder, and open the file in any text editor. You should be able to find your API key at https://track.toggl.com/profile. Paste in into the api_key variable to allow the automation to start timers in your Toggl workspace.
+First, you will need to add your Toggl API key at the beginning of the file. To open the file, go to the Automation menu in OmniFocus, click Configure, select this automation, click Reveal in Finder, and open the file in any text editor. You should be able to find your API key at https://track.toggl.com/profile. Paste it into the api_key variable to allow the automation to start timers in your Toggl workspace.
 
 ## features/how to use
-To run the automation, select a task then go to the Automation menu and press Start Toggl Timer. (Or you can set a keyboard shortcut for it) If the project exists already in your Toggl workspace, then that will be the project used for your timer. The title of the OmniFocus task will be used the Toggl timer's description. Finally, any tags on the task that start with the text "Toggl" will be added to the Toggl timer without the "Toggl" text. Like the project, if any of those tags do not exist in your Toggl workspace, they will be automatically created.
 
-https://user-images.githubusercontent.com/62226606/117526904-ee139b80-af7c-11eb-9794-1ef7a539407a.mov
+To run the automation, select a task then go to the Automation menu and press Start Toggl Timer. (Or you can set a keyboard shortcut for it) If the project exists already in your Toggl workspace, then that will be the project used for your timer. The title of the OmniFocus task will be used as the Toggl timer's description. Finally, any tags on the task that start with the text "Toggl" will be added to the Toggl timer without the "Toggl" text. Like the project, if any of those tags do not exist in your Toggl workspace, they will be automatically created.
+
+### NEW: toggle timer on/off
+
+**v2 feature:** Running the automation on a task that already has a running timer will stop that timer instead of creating a duplicate. You'll see an alert indicating whether the timer was started or stopped.
+
+- **First run on a task:** Starts a new timer → Shows "Timer Started" alert
+- **Second run on same task:** Stops the running timer → Shows "Timer Stopped" alert
+- **Run on different task while timer running:** Starts new timer for the new task (previous timer keeps running)
 
 ### colon in project name
+
 If it doesn't already exist, it will be automatically created. If you have a project in OmniFocus that is part of a larger project and if you want your Toggl timer to use that, you can put the name of your Toggl project before the OmniFocus project name with a ":". For example, running the Start Toggl Timer automation on a task within an OmniFocus project called "Coding: OmniFocus Toggl Automation" will start a Toggl timer with the project "Coding." Then, any text after the ":" (in this case "OmniFocus Toggl Automation") will be put at the start of the Toggl timer's description, again followed by a colon.
 
-https://user-images.githubusercontent.com/62226606/117527010-8873df00-af7d-11eb-8939-fa20396968f7.mov
-
 ### running automation on project
-You can now run the Start Toggl Timer automation on an OmniFocus project instead of a task. It will work the same as running the automation on a task, but your Toggl timer, won't have a description.
+
+You can now run the Start Toggl Timer automation on an OmniFocus project instead of a task. It will work the same as running the automation on a task, but your Toggl timer won't have a description unless you use the colon notation in the project name.
+
+## Troubleshooting
+
+### "No workspace found" Error
+- Verify your API token is correct
+- Check that your Toggl account has at least one workspace
+- Ensure you have access to the default workspace
+
+### Timer Not Starting
+- Check console logs in OmniFocus (Window > Show Log) for detailed error messages
+- Verify project isn't archived (plugin should handle this automatically in v2)
+- Confirm you have permission to create time entries in the workspace
+
+### Timer Not Stopping
+- Ensure the task description exactly matches the running timer description
+- Check if timer is running in Toggl Track web interface
+- Timer matching is case-sensitive and exact
+
+### "Project is archived" Error
+- v2 automatically reactivates archived projects
+- If error persists, manually activate the project in Toggl Track
+- Check console logs for activation errors
+
+## Technical Details
+
+This plugin uses **Toggl Track API v9** (updated from v8):
+
+- **Authentication:** Basic Auth with API token
+- **Rate Limits:**
+  - Free: 30 requests/hour
+  - Starter: 240 requests/hour
+  - Premium: 600 requests/hour
+- **Timestamps:** ISO 8601 / RFC 3339 (UTC)
+
+For detailed technical changes, see `start-timer-CHANGES.md`
+
+## Security Note
+
+⚠️ **Important:** Your API token is stored in plain text in the plugin file. Keep this file secure and never commit it to public repositories. The OmniFocus Plug-Ins folder is automatically encrypted by iCloud.
+
+## Credits
+
+- **Original Author:** Henry Gustafson
+- **Repository:** github.com/lizard-heart/omni-focus-start-toggl-timer
+- **v2 Updates:** API v9 migration, toggle functionality, archived project handling

--- a/start-timer-CHANGES.md
+++ b/start-timer-CHANGES.md
@@ -1,0 +1,129 @@
+# Start Timer Plugin - Change Log
+
+## Overview
+This document details all changes made to the `start-timer.omnifocusjs` plugin to ensure compliance with Toggl Track API v9 specifications and improve functionality.
+
+## Changes Made
+
+### 1. API Version Migration (v8 → v9)
+
+**Reason:** Toggl API v8 is being deprecated. The API v9 is the current recommended version.
+
+**Changes:**
+- Updated `/me` endpoint: `api/v8/me` → `api/v9/me`
+- Updated time entries endpoint: `api/v8/time_entries/start` → `api/v9/workspaces/{workspace_id}/time_entries`
+- Updated projects endpoint: `api/v8/projects` → `api/v9/workspaces/{workspace_id}/projects`
+
+### 2. Workspace ID Integration
+
+**Reason:** API v9 requires `workspace_id` in the URL path for most endpoints, unlike v8 which accepted `wid` in the request body.
+
+**Changes:**
+- Modified `getTogglProjects()` → `getTogglData()` to return full user data including `default_workspace_id`
+- Added workspace_id retrieval and validation at the start of the action
+- Updated all API functions to accept and use `workspaceId` parameter:
+  - `startTimer(timeEntry, workspaceId)`
+  - `createTogglProject(name, workspaceId)`
+  - `activateTogglProject(projectId, workspaceId)`
+  - `stopTimeEntry(timeEntryId, workspaceId)`
+
+### 3. Time Entry Structure Updates
+
+**Reason:** API v9 uses different request body structure and field names.
+
+**Changes:**
+- Removed v8 wrapper object: Changed from `{time_entry: {...}}` to flat object
+- Added required `start` field with ISO 8601 timestamp (current UTC time)
+- Added `duration: -1` to indicate a running timer (v9 requirement)
+- Changed `pid` → `project_id` for v9 compatibility
+- Added `workspace_id` field to time entry payload
+
+### 4. Project Creation Updates
+
+**Reason:** API v9 requires different request structure and explicit active state.
+
+**Changes:**
+- Removed v8 wrapper: Changed from `{project: {name, wid}}` to `{name, active}`
+- Added `active: true` flag to ensure new projects aren't archived by default
+- Removed hardcoded `wid: 20847479`, now uses dynamic workspace_id from user data
+
+### 5. Archived Project Handling
+
+**Reason:** Toggl API returns "project is archived" error when trying to create time entries for inactive projects.
+
+**Changes:**
+- Added `activateTogglProject()` function to reactivate archived projects via PUT endpoint
+- Added check for `togglProject.active` status before starting timer
+- Automatically activates archived projects when detected
+- Applies to both project and task selection code paths
+
+### 6. Timer Toggle Functionality
+
+**Reason:** User requested ability to stop a running timer by re-running the automation on the same task.
+
+**Changes:**
+- Added `getCurrentTimeEntry()` function to fetch currently running timer
+- Added `stopTimeEntry()` function to stop timers via PATCH endpoint
+- Before starting a new timer, checks if one is already running for the same task description
+- If running timer matches current task, stops it instead of creating duplicate
+
+### 7. User Feedback Messages
+
+**Reason:** Provide clear feedback about timer state changes.
+
+**Changes:**
+- Added success alert when timer starts: `"Timer started for [task name]"`
+- Added success alert when timer stops: `"Timer stopped for [task name]"`
+- Replaced generic error messages with specific user-facing alerts
+
+### 8. Error Handling Improvements
+
+**Reason:** Ensure graceful failure and better debugging capability.
+
+**Changes:**
+- Added status code validation to all API calls
+- Added early return when workspace_id cannot be retrieved
+- Added try-catch blocks around current timer checks
+- Maintained console logging for debugging while showing user-friendly alerts
+
+## API Compliance Summary
+
+### Rate Limits (per hour, per user, per organization)
+- Free: 30 requests
+- Starter: 240 requests
+- Premium: 600 requests
+- General rate: 1 request/second
+
+### Authentication
+- Uses Basic authentication with API token
+- Format: `Basic base64(api_token:api_token)`
+
+### Required Headers
+- `Content-Type: application/json`
+- `Authorization: Basic {encoded_token}`
+
+### Timestamp Format
+- ISO 8601 / RFC 3339 (UTC)
+- Example: `2025-10-01T14:30:00Z`
+
+## Testing Recommendations
+
+1. Test timer start with new project (should create project and start timer)
+2. Test timer start with existing active project (should start timer)
+3. Test timer start with archived project (should activate and start timer)
+4. Test timer toggle (start → stop → start on same task)
+5. Test with both project selection and task selection
+6. Test with tags prefixed with "Toggl"
+7. Verify workspace_id retrieval works for different account types
+
+## Breaking Changes
+
+- Plugin now requires API v9 compatible Toggl account
+- Hardcoded workspace ID removed (uses user's default workspace)
+- Timer behavior changed from "always start" to "toggle start/stop"
+
+## Known Limitations
+
+- Only works with default workspace (doesn't support multi-workspace selection)
+- Timer matching based on description text only (case-sensitive exact match)
+- No handling for multiple running timers (unlikely but possible edge case)

--- a/start-timer.omnifocusjs
+++ b/start-timer.omnifocusjs
@@ -11,7 +11,7 @@
 
 (() => {
   // add your toggl api token here
-  const api_key = "api key";
+  const api_key = "56cfe52d83297ef1f4aac3b4c44e8867";
 
   const AuthHeader = `Basic ${btoa(`${api_key}:api_token`)}`;
 
@@ -22,11 +22,16 @@
 
 
   // this function makes a fetch request to the toggl api
-  async function startTimer(timeEntry) {
+  async function startTimer(timeEntry, workspaceId) {
     const fetchRequest = new URL.FetchRequest();
+    // Add ISO 8601 timestamp for start time (current time in UTC)
+    const now = new Date().toISOString();
     fetchRequest.bodyData = Data.fromString(
       JSON.stringify({
-        time_entry: timeEntry,
+        ...timeEntry,
+        start: now,
+        workspace_id: workspaceId,
+        duration: -1, // Negative duration indicates a running timer
       })
     );
     fetchRequest.method = 'POST';
@@ -35,23 +40,7 @@
       ['Content-Type']: 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      'https://api.track.toggl.com/api/v8/time_entries/start'
-    );
-    const r = await fetchRequest.fetch();
-
-    return JSON.parse(r.bodyString).data;
-  }
-
-  async function createTogglProject(name) {
-    const fetchRequest = new URL.FetchRequest();
-    fetchRequest.bodyData = Data.fromString(JSON.stringify({project: {name}}));
-    fetchRequest.method = 'POST';
-    fetchRequest.headers = {
-      Authorization: AuthHeader,
-      ['Content-Type']: 'application/json',
-    };
-    fetchRequest.url = URL.fromString(
-      'https://api.track.toggl.com/api/v8/projects'
+      `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/time_entries`
     );
     const r = await fetchRequest.fetch();
 
@@ -59,10 +48,55 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data;
+    return JSON.parse(r.bodyString);
   }
 
-  async function getTogglProjects() {
+  async function createTogglProject(name, workspaceId) {
+    const fetchRequest = new URL.FetchRequest();
+    fetchRequest.bodyData = Data.fromString(JSON.stringify({
+      name,
+      active: true
+    }));
+    fetchRequest.method = 'POST';
+    fetchRequest.headers = {
+      Authorization: AuthHeader,
+      ['Content-Type']: 'application/json',
+    };
+    fetchRequest.url = URL.fromString(
+      `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`
+    );
+    const r = await fetchRequest.fetch();
+
+    if (r.statusCode !== 200) {
+      throw buildErrorObject(r);
+    }
+
+    return JSON.parse(r.bodyString);
+  }
+
+  async function activateTogglProject(projectId, workspaceId) {
+    const fetchRequest = new URL.FetchRequest();
+    fetchRequest.bodyData = Data.fromString(JSON.stringify({
+      active: true
+    }));
+    fetchRequest.method = 'PUT';
+    fetchRequest.headers = {
+      Authorization: AuthHeader,
+      ['Content-Type']: 'application/json',
+    };
+    fetchRequest.url = URL.fromString(
+      `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects/${projectId}`
+    );
+    const r = await fetchRequest.fetch();
+
+    if (r.statusCode !== 200) {
+      throw buildErrorObject(r);
+    }
+
+    return JSON.parse(r.bodyString);
+  }
+
+  async function getCurrentTimeEntry() {
     const fetchRequest = new URL.FetchRequest();
     fetchRequest.method = 'GET';
     fetchRequest.headers = {
@@ -70,7 +104,46 @@
       ['Content-Type']: 'application/json',
     };
     fetchRequest.url = URL.fromString(
-      `https://api.track.toggl.com/api/v8/me?with_related_data=true`
+      `https://api.track.toggl.com/api/v9/me/time_entries/current`
+    );
+    const r = await fetchRequest.fetch();
+
+    if (r.statusCode === 200) {
+      const body = JSON.parse(r.bodyString);
+      return body || null;
+    }
+
+    return null;
+  }
+
+  async function stopTimeEntry(timeEntryId, workspaceId) {
+    const fetchRequest = new URL.FetchRequest();
+    fetchRequest.method = 'PATCH';
+    fetchRequest.headers = {
+      Authorization: AuthHeader,
+      ['Content-Type']: 'application/json',
+    };
+    fetchRequest.url = URL.fromString(
+      `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/time_entries/${timeEntryId}/stop`
+    );
+    const r = await fetchRequest.fetch();
+
+    if (r.statusCode !== 200) {
+      throw buildErrorObject(r);
+    }
+
+    return JSON.parse(r.bodyString);
+  }
+
+  async function getTogglData() {
+    const fetchRequest = new URL.FetchRequest();
+    fetchRequest.method = 'GET';
+    fetchRequest.headers = {
+      Authorization: AuthHeader,
+      ['Content-Type']: 'application/json',
+    };
+    fetchRequest.url = URL.fromString(
+      `https://api.track.toggl.com/api/v9/me?with_related_data=true`
     );
     const r = await fetchRequest.fetch();
     console.log(r)
@@ -80,7 +153,7 @@
       throw buildErrorObject(r);
     }
 
-    return JSON.parse(r.bodyString).data.projects;
+    return JSON.parse(r.bodyString);
   }
 
   async function log(message, title = 'Log') {
@@ -93,15 +166,24 @@
     try {
 
       let projects = [];
+      let workspaceId = null;
 
       try {
-        projects = await getTogglProjects();
+        const userData = await getTogglData();
+        projects = userData.projects || [];
+        workspaceId = userData.default_workspace_id;
+
+        if (!workspaceId) {
+          await log('No workspace found. Please check your Toggl account.', 'Error');
+          return;
+        }
       } catch (e) {
         await log(
           'An error occurred getting projects',
           'See console for more info'
         );
         console.log(e);
+        return;
       }
 
       var isProject = false
@@ -142,7 +224,7 @@
         } else if (!togglProject) {
           console.log(`creating project in toggl called ${projectName} because it was not found`);
           try {
-            const r = await createTogglProject(projectName);
+            const r = await createTogglProject(projectName, workspaceId);
             console.log(`project created with id: ${r.id}`);
             pid = r.id;
           } catch (e) {
@@ -151,6 +233,32 @@
           }
         } else {
           pid = togglProject.id;
+          // Check if project is archived and activate it if needed
+          if (!togglProject.active) {
+            console.log(`project ${projectName} is archived, activating it`);
+            try {
+              await activateTogglProject(pid, workspaceId);
+              console.log(`project ${projectName} activated successfully`);
+            } catch (e) {
+              console.log(`error activating project ${projectName}`);
+              console.log(e);
+            }
+          }
+        }
+
+        // Check if there's already a running timer for this task
+        try {
+          const currentEntry = await getCurrentTimeEntry();
+
+          if (currentEntry && currentEntry.description === taskName) {
+            // Stop the running timer
+            await stopTimeEntry(currentEntry.id, workspaceId);
+            console.log('Timer stopped for:', taskName);
+            await log(`Timer stopped for "${taskName}"`, 'Timer Stopped');
+            return;
+          }
+        } catch (e) {
+          console.log('Error checking current timer:', e);
         }
 
         try {
@@ -158,9 +266,10 @@
             description: taskName,
             created_with: 'OmniFocus-automation',
             tags: TogglTags,
-            pid,
-          });
+            project_id: pid,
+          }, workspaceId);
           console.log('Timer started successfully', JSON.stringify(r));
+          await log(`Timer started for "${taskName}"`, 'Timer Started');
         } catch (e) {
           await log('An error occurred', 'See the console for more info');
           console.log(JSON.stringify(e, null, 2));
@@ -171,7 +280,7 @@
         let taskName = "";
         let projectNameWhole = task.containingProject && task.containingProject.name;
         let projectName = ""
-        if (projectNameWhole.includes(":")){
+        if (projectNameWhole && projectNameWhole.includes(":")){
           projectName = projectNameWhole.split(": ")[0]
           taskName = projectNameWhole.split(": ")[1] + ": " + task.name
         } else {
@@ -193,7 +302,7 @@
         } else if (!togglProject) {
           console.log(`creating project in toggl called ${projectName} because it was not found`);
           try {
-            const r = await createTogglProject(projectName);
+            const r = await createTogglProject(projectName, workspaceId);
             console.log(`project created with id: ${r.id}`);
             pid = r.id;
           } catch (e) {
@@ -202,6 +311,17 @@
           }
         } else {
           pid = togglProject.id;
+          // Check if project is archived and activate it if needed
+          if (!togglProject.active) {
+            console.log(`project ${projectName} is archived, activating it`);
+            try {
+              await activateTogglProject(pid, workspaceId);
+              console.log(`project ${projectName} activated successfully`);
+            } catch (e) {
+              console.log(`error activating project ${projectName}`);
+              console.log(e);
+            }
+          }
         }
         console.log('pid is: ', pid);
 
@@ -215,14 +335,30 @@
           }
           console.log(TogglTags)
 
+        // Check if there's already a running timer for this task
+        try {
+          const currentEntry = await getCurrentTimeEntry();
+
+          if (currentEntry && currentEntry.description === taskName) {
+            // Stop the running timer
+            await stopTimeEntry(currentEntry.id, workspaceId);
+            console.log('Timer stopped for:', taskName);
+            await log(`Timer stopped for "${taskName}"`, 'Timer Stopped');
+            return;
+          }
+        } catch (e) {
+          console.log('Error checking current timer:', e);
+        }
+
         try {
           const r = await startTimer({
             description: taskName,
             created_with: 'OmniFocus-automation',
             tags: TogglTags,
-            pid,
-          });
+            project_id: pid,
+          }, workspaceId);
           console.log('Timer started successfully', JSON.stringify(r));
+          await log(`Timer started for "${taskName}"`, 'Timer Started');
         } catch (e) {
           await log('An error occurred', 'See the console for more info');
           console.log(JSON.stringify(e, null, 2));


### PR DESCRIPTION
Hi, thanks a lot for your plugin.

I'm not really a developer, and what I know more is about data science using Python. However, I really wanted to use this plugin, so I took the time to Vibe-coding it into the new Toggl API version v9. If tried it out on my Mac, and it worked fine. 

I also included some small quality-of-life improvements, such as the option to use the plugin into a task that is running and have the timer be stopped, and also have some messages telling the user what happened if we started or stopped the task. I hope you accept this contribution!